### PR TITLE
chore: ensure we don't try to compile any C++ code

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,6 +14,9 @@ common --action_env=RULES_PYTHON_ENABLE_PYSTAR=0
 # https://bazelbuild.slack.com/archives/C014RARENH0/p1691158021917459?thread_ts=1691156601.420349&cid=C014RARENH0
 common --check_direct_dependencies=off
 
+# Force rules_go to disable CGO even though we have a (fake) C++ toolchain registered.
+common --host_platform=//:no_cgo_host_platform
+
 # Load any settings specific to the current user.
 # .bazelrc.user should appear in .gitignore so that settings are not shared with team members
 # This needs to be last statement in this

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
+
+platform(
+    name = "no_cgo_host_platform",
+    constraint_values = HOST_CONSTRAINTS + [
+        "@rules_go//go/toolchain:cgo_off",
+    ],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ module(
 bazel_dep(name = "bazel_features", version = "1.9.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "rules_proto", version = "6.0.0")
-bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "platforms", version = "0.0.10")
 
 protoc = use_extension("//protoc:extensions.bzl", "protoc")
 protoc.toolchain(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,7 +21,7 @@ use_repo(protoc, "com_google_protobuf", "toolchains_protoc_hub")
 register_toolchains("@toolchains_protoc_hub//:all")
 
 # Assert no CC compilation occurs
-register_toolchains("//tools/toolchains:all")
+register_toolchains("//tools/toolchains:all", dev_dependency = True)
 
 bazel_dep(name = "aspect_bazel_lib", version = "1.32.1", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "6.1.2", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,6 +20,9 @@ use_repo(protoc, "com_google_protobuf", "toolchains_protoc_hub")
 
 register_toolchains("@toolchains_protoc_hub//:all")
 
+# Assert no CC compilation occurs
+register_toolchains("//tools/toolchains:all")
+
 bazel_dep(name = "aspect_bazel_lib", version = "1.32.1", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "6.1.2", dev_dependency = True)
 bazel_dep(name = "aspect_rules_py", version = "0.7.1", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,7 +21,10 @@ use_repo(protoc, "com_google_protobuf", "toolchains_protoc_hub")
 register_toolchains("@toolchains_protoc_hub//:all")
 
 # Assert no CC compilation occurs
-register_toolchains("//tools/toolchains:all", dev_dependency = True)
+register_toolchains(
+    "//tools/toolchains:all",
+    dev_dependency = True,
+)
 
 bazel_dep(name = "aspect_bazel_lib", version = "1.32.1", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "6.1.2", dev_dependency = True)

--- a/tools/toolchains/BUILD.bazel
+++ b/tools/toolchains/BUILD.bazel
@@ -1,0 +1,31 @@
+"""Define a non-functional cc toolchain.
+
+To fail-fast in cases where we are forced to compile third-party C++ code,
+define a cc toolchain that doesn't work, by using 'false' as the compiler.
+See https://bazel.build/tutorials/ccp-toolchain-config
+"""
+
+load("defs.bzl", "cc_toolchain_config")
+
+filegroup(name = "empty")
+
+cc_toolchain_config(name = "noop_toolchain_config")
+
+cc_toolchain(
+    name = "noop_toolchain",
+    all_files = ":empty",
+    compiler_files = ":empty",
+    dwp_files = ":empty",
+    linker_files = ":empty",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    supports_param_files = 0,
+    toolchain_config = ":noop_toolchain_config",
+    toolchain_identifier = "noop-toolchain",
+)
+
+toolchain(
+    name = "cc_toolchain",
+    toolchain = ":noop_toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)

--- a/tools/toolchains/defs.bzl
+++ b/tools/toolchains/defs.bzl
@@ -1,0 +1,20 @@
+"Configure a cc toolchain to call 'false' if used."
+
+def _impl(ctx):
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx,
+        toolchain_identifier = "noop-toolchain",
+        host_system_name = "local",
+        target_system_name = "local",
+        target_cpu = "k8",
+        target_libc = "unknown",
+        compiler = "false",
+        abi_version = "unknown",
+        abi_libc_version = "unknown",
+    )
+
+cc_toolchain_config = rule(
+    implementation = _impl,
+    attrs = {},
+    provides = [CcToolchainConfigInfo],
+)


### PR DESCRIPTION
We don't have any C++ code in this repo, and want to make sure that our examples don't transitively depend on building protoc from source.

#13 should have been red due to the issue I fixed in https://github.com/protocolbuffers/protobuf/pull/17078

This change ensures that PR and any others that regress will be caught by CI.

It should be the case that users with a broken or non-hermetic CC toolchain are still able to work with Protocol Buffers.
