### PR TITLE
Fix download filename for RC versions

### DIFF
--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -19,7 +19,7 @@ protoc = use_extension("@toolchains_protoc//protoc:extensions.bzl", "protoc")
 protoc.toolchain(
     google_protobuf = "com_google_protobuf",
     # Demonstrate overriding the default version
-    version = "v28.0",
+    version = "LATEST",
 )
 use_repo(protoc, "com_google_protobuf", "toolchains_protoc_hub")
 

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -19,7 +19,7 @@ protoc = use_extension("@toolchains_protoc//protoc:extensions.bzl", "protoc")
 protoc.toolchain(
     google_protobuf = "com_google_protobuf",
     # Demonstrate overriding the default version
-    version = "LATEST",
+    version = "v28.0",
 )
 use_repo(protoc, "com_google_protobuf", "toolchains_protoc_hub")
 

--- a/protoc/private/BUILD.bazel
+++ b/protoc/private/BUILD.bazel
@@ -1,7 +1,10 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load(":prebuilt_protoc_toolchain_test.bzl", "release_version_to_artifact_name_test_suite")
 
 bzl_library(
     name = "versions",
     srcs = ["versions.bzl"],
     visibility = ["//protoc:__subpackages__"],
 )
+
+release_version_to_artifact_name_test_suite()

--- a/protoc/private/prebuilt_protoc_toolchain.bzl
+++ b/protoc/private/prebuilt_protoc_toolchain.bzl
@@ -22,15 +22,28 @@ GOOGLE_PROTOBUF_DEP_EDGES = {
     "wrappers": [],
 }
 
+def release_version_to_artifact_name(release_version, platform):
+    # versions have a "v" prefix like "v28.0"
+    stripped_version = release_version.removeprefix("v")
+
+    # release candidate versions like "v29.0-rc3" have artifact names
+    # like "protoc-29.0-rc-3-osx-x86_64.zip"
+    artifact_version = stripped_version.replace("rc", "rc-")
+
+    return "{}-{}-{}.zip".format(
+        "protoc",
+        artifact_version,
+        platform,
+    )
+
 def _prebuilt_protoc_repo_impl(rctx):
     release_version = rctx.attr.version
     if release_version == "LATEST":
         release_version = PROTOC_VERSIONS.keys()[0]
 
-    filename = "{}-{}-{}.zip".format(
-        "protoc",
-        release_version.removeprefix("v"),
-        rctx.attr.platform,
+    filename = release_version_to_artifact_name(
+        release_version,
+        rctx.attr.platform
     )
     url = "https://github.com/protocolbuffers/protobuf/releases/download/{}/{}".format(
         release_version,

--- a/protoc/private/prebuilt_protoc_toolchain.bzl
+++ b/protoc/private/prebuilt_protoc_toolchain.bzl
@@ -43,7 +43,7 @@ def _prebuilt_protoc_repo_impl(rctx):
 
     filename = release_version_to_artifact_name(
         release_version,
-        rctx.attr.platform
+        rctx.attr.platform,
     )
     url = "https://github.com/protocolbuffers/protobuf/releases/download/{}/{}".format(
         release_version,

--- a/protoc/private/prebuilt_protoc_toolchain_test.bzl
+++ b/protoc/private/prebuilt_protoc_toolchain_test.bzl
@@ -8,23 +8,24 @@ load(":prebuilt_protoc_toolchain.bzl", "release_version_to_artifact_name")
 load(":versions.bzl", "PROTOC_VERSIONS")
 
 def _release_version_to_artifact_name_test_impl(ctx):
-  env = unittest.begin(ctx)
-  count = 0
+    env = unittest.begin(ctx)
+    count = 0
 
-  for release_version in PROTOC_VERSIONS:
-      artifact_name = release_version_to_artifact_name(release_version, "linux-x86_64")
-      artifact_dict = PROTOC_VERSIONS[release_version]
-      # there should be a linux-x86_64 artifact in every release
-      asserts.true(env, artifact_name in artifact_dict, "'{}' not found for release version '{}'".format(artifact_name, release_version))
-      count += 1
+    for release_version in PROTOC_VERSIONS:
+        artifact_name = release_version_to_artifact_name(release_version, "linux-x86_64")
+        artifact_dict = PROTOC_VERSIONS[release_version]
 
-  asserts.true(env, count > 0, "no versions tested")
-  return unittest.end(env)
+        # there should be a linux-x86_64 artifact in every release
+        asserts.true(env, artifact_name in artifact_dict, "'{}' not found for release version '{}'".format(artifact_name, release_version))
+        count += 1
+
+    asserts.true(env, count > 0, "no versions tested")
+    return unittest.end(env)
 
 release_version_to_artifact_name_test = unittest.make(_release_version_to_artifact_name_test_impl)
 
 def release_version_to_artifact_name_test_suite():
-  unittest.suite(
-    "release_version_to_artifact_name_tests",
-    release_version_to_artifact_name_test,
-  )
+    unittest.suite(
+        "release_version_to_artifact_name_tests",
+        release_version_to_artifact_name_test,
+    )

--- a/protoc/private/prebuilt_protoc_toolchain_test.bzl
+++ b/protoc/private/prebuilt_protoc_toolchain_test.bzl
@@ -1,0 +1,30 @@
+"""Unit test suite for version-to-artifact-name resolution helper.
+
+Based on the example at https://bazel.build/rules/testing#testing-starlark-utilities
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(":prebuilt_protoc_toolchain.bzl", "release_version_to_artifact_name")
+load(":versions.bzl", "PROTOC_VERSIONS")
+
+def _release_version_to_artifact_name_test_impl(ctx):
+  env = unittest.begin(ctx)
+  count = 0
+
+  for release_version in PROTOC_VERSIONS:
+      artifact_name = release_version_to_artifact_name(release_version, "linux-x86_64")
+      artifact_dict = PROTOC_VERSIONS[release_version]
+      # there should be a linux-x86_64 artifact in every release
+      asserts.true(env, artifact_name in artifact_dict, "'{}' not found for release version '{}'".format(artifact_name, release_version))
+      count += 1
+
+  asserts.true(env, count > 0, "no versions tested")
+  return unittest.end(env)
+
+release_version_to_artifact_name_test = unittest.make(_release_version_to_artifact_name_test_impl)
+
+def release_version_to_artifact_name_test_suite():
+  unittest.suite(
+    "release_version_to_artifact_name_tests",
+    release_version_to_artifact_name_test,
+  )


### PR DESCRIPTION
Forked PR from #33 (I don't have permission to push to that branch)

fixes #32

### What is this?
This PR fixes filename resolution for release candidate version of protoc. RC names like `29.0-rc3` have release artifacts with names like `29.0-rc-3...`. see the release assets for [29.0-rc3](https://github.com/protocolbuffers/protobuf/releases/tag/v29.0-rc3) or [28.0-rc2](https://github.com/protocolbuffers/protobuf/releases/tag/v28.0-rc2)

### Changes are visible to end-users: no

### Test plan

<!-- Delete any which do not apply -->

- Pretty much covered by existing test cases with example protoc version changed to `LATEST`
- Added unit test to validate release_version -> artifact_name against supported versions