### PR TITLE
feat: re-enable Java example of using pre-built protoc

### DIFF
--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -73,8 +73,8 @@ http_jar = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_j
 
 http_jar(
     name = "protobuf-java",
-    sha256 = "0532ad1024d62361561acaedb974d7d16889e7670b36e23e9321dd6b9d334ef9",
-    urls = ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/4.27.0-RC3/protobuf-java-4.27.0-RC3.jar"],
+    integrity = "sha256-rSOIR3s7lplCQeZHMaE2iU3J/tbeufJ21ISosXGxRQw=",
+    urls = ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/4.28.0/protobuf-java-4.28.0.jar"],
 )
 
 ####### RUST ##########

--- a/examples/java/BUILD
+++ b/examples/java/BUILD
@@ -1,10 +1,9 @@
-# See comment in examples/BUILD.bazel
-# java_binary(
-#     name = "java",
-#     srcs = ["Main.java"],
-#     main_class = "Main",
-#     deps = [
-#         "//:foo_java_proto",
-#         "@protobuf-java//jar",
-#     ],
-# )
+java_binary(
+    name = "java",
+    srcs = ["Main.java"],
+    main_class = "Main",
+    deps = [
+        "//proto:greeter_java_proto",
+        "@protobuf-java//jar",
+    ],
+)

--- a/examples/java/Main.java
+++ b/examples/java/Main.java
@@ -1,14 +1,14 @@
 import com.google.protobuf.InvalidProtocolBufferException;
-import static proto.FooOuterClass.Foo;
+import static proto.GreeterOuterClass.HelloReply;
 
 public class Main {
   public static void main(String[] args) throws InvalidProtocolBufferException {
     System.out.println(makeMessage("Hello World!"));
   }
 
-  public static Foo makeMessage(String msg) {
-    Foo.Builder person = Foo.newBuilder();
-    person.setMsg(msg);
-    return person.build();
+  public static HelloReply makeMessage(String msg) {
+    HelloReply.Builder response = HelloReply.newBuilder();
+    response.setMessage(msg);
+    return response.build();
   }
 }

--- a/examples/proto/BUILD.bazel
+++ b/examples/proto/BUILD.bazel
@@ -17,13 +17,10 @@ py_proto_library(
     deps = [":greeter_proto"],
 )
 
-# Broken by https://github.com/protocolbuffers/protobuf/pull/19679
-# which causes building C++ code from source.
-# TODO: re-enable once protobuf honors the toolchain
-# java_proto_library(
-#     name = "greeter_java_proto",
-#     deps = [":greeter_proto"],
-# )
+java_proto_library(
+    name = "greeter_java_proto",
+    deps = [":greeter_proto"],
+)
 
 go_proto_library(
     name = "greeter_go_proto",


### PR DESCRIPTION
Also serves as a reproduction for https://github.com/protocolbuffers/protobuf/pull/19679

Testing:

```
% bazel run java       
INFO: Analyzed target //java:java (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //java:java up-to-date:
  bazel-bin/java/java
  bazel-bin/java/java.jar
INFO: Elapsed time: 0.089s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/java/java
message: "Hello World!"
```