### PR TITLE
Fix mirror protoc release github action

### DIFF
--- a/.github/workflows/mirror_protoc_release.yml
+++ b/.github/workflows/mirror_protoc_release.yml
@@ -12,6 +12,7 @@ on:
 # Allow the pull request we create to run checks
 permissions:
   contents: write
+  pull-requests: write
   actions: write
 
 jobs:


### PR DESCRIPTION
This PR fixes the github action that auto updates the protoc versions.
It was missing a now required permissions for the job `pull_requests: write` as mentioned in the action repo https://github.com/peter-evans/create-pull-request/tree/v6/?tab=readme-ov-file#workflow-permissions

### Test plan

Tried on my own fork and succeeded.

https://github.com/cerisier/toolchains_protoc/actions/runs/13076038587 