### PR TITLE
example: work around for making java work

### DIFF
--- a/examples/19679.patch
+++ b/examples/19679.patch
@@ -1,0 +1,92 @@
+diff --git a/protobuf.bzl b/protobuf.bzl
+index 283c858507e47..ad91faba65570 100644
+--- a/protobuf.bzl
++++ b/protobuf.bzl
+@@ -1,7 +1,9 @@
+ load("@bazel_skylib//lib:versions.bzl", "versions")
+ load("@rules_cc//cc:defs.bzl", "objc_library")
+ load("@rules_python//python:defs.bzl", "py_library")
++load("//bazel/common:proto_common.bzl", "proto_common")
+ load("//bazel/common:proto_info.bzl", "ProtoInfo")
++load("//bazel/private:toolchain_helpers.bzl", "toolchains")
+ 
+ def _GetPath(ctx, path):
+     if ctx.label.workspace_root:
+@@ -71,6 +73,26 @@ def _CsharpOuts(srcs):
+         for src in srcs
+     ]
+ 
++_PROTOC_ATTRS = toolchains.if_legacy_toolchain({
++    "_proto_compiler": attr.label(
++        cfg = "exec",
++        executable = True,
++        allow_files = True,
++        default = configuration_field("proto", "proto_compiler"),
++    ),
++})
++_PROTOC_FRAGMENTS = ["proto"]
++_PROTOC_TOOLCHAINS = toolchains.use_toolchain(toolchains.PROTO_TOOLCHAIN)
++
++def _protoc_files_to_run(ctx):
++    if proto_common.INCOMPATIBLE_ENABLE_PROTO_TOOLCHAIN_RESOLUTION:
++        toolchain = ctx.toolchains[toolchains.PROTO_TOOLCHAIN]
++        if not toolchain:
++            fail("Protocol compiler toolchain could not be resolved.")
++        return toolchain.proto.proto_compiler
++    else:
++        return ctx.attr._proto_compiler[DefaultInfo].files_to_run
++
+ ProtoGenInfo = provider(
+     fields = ["srcs", "import_flags", "deps"],
+ )
+@@ -310,7 +332,7 @@ def _internal_gen_well_known_protos_java_impl(ctx):
+             args.add_all([src.path[offset:] for src in dep.direct_sources])
+ 
+     ctx.actions.run(
+-        executable = ctx.executable._protoc,
++        executable = _protoc_files_to_run(ctx),
+         inputs = descriptors,
+         outputs = [srcjar],
+         arguments = [args],
+@@ -334,12 +356,9 @@ internal_gen_well_known_protos_java = rule(
+         "javalite": attr.bool(
+             default = False,
+         ),
+-        "_protoc": attr.label(
+-            executable = True,
+-            cfg = "exec",
+-            default = "//:protoc",
+-        ),
+-    },
++    } | _PROTOC_ATTRS,
++    fragments = _PROTOC_FRAGMENTS,
++    toolchains = _PROTOC_TOOLCHAINS,
+ )
+ 
+ def _internal_gen_kt_protos(ctx):
+@@ -373,7 +392,7 @@ def _internal_gen_kt_protos(ctx):
+             args.add_all([src.path[offset:] for src in dep.direct_sources])
+ 
+     ctx.actions.run(
+-        executable = ctx.executable._protoc,
++        executable = _protoc_files_to_run(ctx),
+         inputs = descriptors,
+         outputs = [srcjar],
+         arguments = [args],
+@@ -397,12 +416,9 @@ internal_gen_kt_protos = rule(
+         "lite": attr.bool(
+             default = False,
+         ),
+-        "_protoc": attr.label(
+-            executable = True,
+-            cfg = "exec",
+-            default = "//:protoc",
+-        ),
+-    },
++    } | _PROTOC_ATTRS,
++    fragments = _PROTOC_FRAGMENTS,
++    toolchains = _PROTOC_TOOLCHAINS,
+ )
+ 
+ def internal_objc_proto_library(
+

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -20,13 +20,17 @@ proto_library(
 # Broken by https://github.com/protocolbuffers/protobuf/pull/19679
 # which causes building C++ code from source.
 # TODO: re-enable once protobuf honors the toolchain
-# java_proto_library(
-#     name = "foo_java_proto",
-#     deps = [":foo_proto"],
-# )
+java_proto_library(
+    name = "foo_java_proto",
+    deps = [":foo_proto"],
+)
 
 go_proto_library(
     name = "foo_go_proto",
     importpath = "example.com/foo_proto",
     proto = ":foo_proto",
 )
+
+exports_files([
+    "19679.patch",
+])

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -8,6 +8,11 @@ bazel_dep(name = "rules_python", version = "1.0.0")
 bazel_dep(name = "rules_go", version = "0.52.0")
 bazel_dep(name = "rules_uv", version = "0.10.0")
 
+bazel_dep(name = "protobuf", version = "29.3")
+single_version_override(module_name = "protobuf", version = "29.3", patch_strip = 1, patches = [
+    "//:19679.patch"
+])
+
 # This example is in the same repo with the ruleset, so we should point to the code at HEAD
 # rather than use any release on the Bazel Central Registry.
 local_path_override(
@@ -20,7 +25,7 @@ protoc = use_extension("@toolchains_protoc//protoc:extensions.bzl", "protoc")
 protoc.toolchain(
     google_protobuf = "com_google_protobuf",
     # Demonstrate overriding the default version
-    version = "v28.0",
+    version = "v29.3",
 )
 use_repo(protoc, "com_google_protobuf", "toolchains_protoc_hub")
 

--- a/examples/java/BUILD
+++ b/examples/java/BUILD
@@ -1,10 +1,10 @@
 # See comment in examples/BUILD.bazel
-# java_binary(
-#     name = "java",
-#     srcs = ["Main.java"],
-#     main_class = "Main",
-#     deps = [
-#         "//:foo_java_proto",
-#         "@protobuf-java//jar",
-#     ],
-# )
+java_binary(
+    name = "java",
+    srcs = ["Main.java"],
+    main_class = "Main",
+    deps = [
+        "//:foo_java_proto",
+        "@protobuf-java//jar",
+    ],
+)


### PR DESCRIPTION
Hey feel free to just close this out. I was trying to get this working in my own repo and it wasn't working so I implemented the change here just to see if something with the patch was bad or my repo. Turns out something in my setup still is trying to build protobufs even with the patch applied because everything works here.

Since I went through the work I thought I would share even if you don't want this upstream it might be nice for someone else. In which case feel free to close.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce: bazel build //... works with java targets
