### PR TITLE
chore: update example to latest bazel deps

### DIFF
--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -1,19 +1,12 @@
 bazel_dep(name = "toolchains_protoc", version = "0.0.0")
 bazel_dep(name = "aspect_bazel_lib", version = "2.11.0")
-bazel_dep(name = "aspect_rules_py", version = "1.0.0")
+bazel_dep(name = "aspect_rules_py", version = "1.3.2")
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "rules_java", version = "8.6.3")
 bazel_dep(name = "rules_proto", version = "7.1.0")
-bazel_dep(name = "rules_python", version = "1.0.0")
-bazel_dep(name = "rules_go", version = "0.52.0")
-bazel_dep(name = "rules_uv", version = "0.52.0")
-
-# Pick up https://github.com/theoremlp/rules_uv/pull/207/commits
-git_override(
-    module_name = "rules_uv",
-    commit = "6330187e9158931d07397e92870a7d5ed12b81f3",
-    remote = "https://github.com/alexeagle/rules_uv.git",
-)
+bazel_dep(name = "rules_python", version = "1.1.0")
+bazel_dep(name = "rules_go", version = "0.53.0")
+bazel_dep(name = "rules_uv", version = "0.56.0")
 
 # This example is in the same repo with the ruleset, so we should point to the code at HEAD
 # rather than use any release on the Bazel Central Registry.


### PR DESCRIPTION
https://github.com/bazelbuild/rules_python/pull/2604 isn't included in a rules_python release so this doesn't prove anything useful.