### PR TITLE
fix: break protobuf and grpc building from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ Using Protocol Buffers with Bazel has always been difficult.
   This makes it difficult to migrate to a monorepo, allowing some applications to move from their separate repo without
   changing their dependency versions.
 
+## Ensure protobuf and gRPC never built
+
+You can ensure that protobuf and grpc is never built from source by breaking the CC compilation.
+
+Simply drop this in your `.bazelrc`
+
+```
+# Ensure that we don't accidentally build protobuf or gRPC
+common --per_file_copt=external/.*protobuf.*@--PROTOBUF_WAS_NOT_SUPPOSED_TO_BE_BUILT
+common --host_per_file_copt=external/.*protobuf.*@--PROTOBUF_WAS_NOT_SUPPOSED_TO_BE_BUILT
+common --per_file_copt=external/.*grpc.*@--GRPC_WAS_NOT_SUPPOSED_TO_BE_BUILT
+common --host_per_file_copt=external/.*grpc.*@--GRPC_WAS_NOT_SUPPOSED_TO_BE_BUILT
+```
+
 ## Support matrix
 
 Minimum versions:

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -6,3 +6,9 @@ common --@aspect_rules_py//py:interpreter_version=3.9.18
 common --host_platform=//tools:no_cgo_host_platform
 common --@aspect_rules_ts//ts:skipLibCheck=always
 common --@aspect_rules_ts//ts:default_to_tsc_transpiler
+
+# Ensure that we don't accidentally build protobuf or gRPC
+common --per_file_copt=external/.*protobuf.*@--PROTOBUF_WAS_NOT_SUPPOSED_TO_BE_BUILT
+common --host_per_file_copt=external/.*protobuf.*@--PROTOBUF_WAS_NOT_SUPPOSED_TO_BE_BUILT
+common --per_file_copt=external/.*grpc.*@--GRPC_WAS_NOT_SUPPOSED_TO_BE_BUILT
+common --host_per_file_copt=external/.*grpc.*@--GRPC_WAS_NOT_SUPPOSED_TO_BE_BUILT


### PR DESCRIPTION
Breaks the CC compilation of grpc and protobuf to help us ensure we never build them from source.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases