### PR TITLE
Remove git_override for rules_python

### DIFF
--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -7,18 +7,11 @@ bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "protobuf", version = "29.3")
 bazel_dep(name = "rules_java", version = "8.6.3")
 bazel_dep(name = "rules_proto", version = "7.1.0")
-bazel_dep(name = "rules_python", version = "1.2.0-rc0")
+bazel_dep(name = "rules_python", version = "1.2.0")
 bazel_dep(name = "rules_rust", version = "0.59.1")
 bazel_dep(name = "rules_rust_prost", version = "0.59.1")
 bazel_dep(name = "rules_go", version = "0.53.0")
 bazel_dep(name = "rules_uv", version = "0.56.0")
-
-# Need https://github.com/bazelbuild/rules_python/pull/2620
-git_override(
-    module_name = "rules_python",
-    commit = "e95f95f75c9078f252f5b03eca18cba12d2e2166",
-    remote = "https://github.com/alexeagle/rules_python.git",
-)
 
 # This example is in the same repo with the ruleset, so we should point to the code at HEAD
 # rather than use any release on the Bazel Central Registry.


### PR DESCRIPTION
The relevant patch (https://github.com/bazelbuild/rules_python/pull/2620) was included in rules_python 1.2.0 so this is no longer needed.

---

### Test plan

- Covered by existing test cases
