### PR TITLE
Add missing load statement for proto_library

### DIFF
--- a/protoc/private/prebuilt_protoc_toolchain.bzl
+++ b/protoc/private/prebuilt_protoc_toolchain.bzl
@@ -60,6 +60,7 @@ def _prebuilt_protoc_repo_impl(rctx):
 package(default_visibility = ["//visibility:public"])
 
 load("@rules_proto//proto:proto_toolchain.bzl", "proto_toolchain")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_toolchain(
     name = "prebuilt_protoc_toolchain",


### PR DESCRIPTION
Generated BUILD.bazel file does not contain required load statement for proto_library:

`load("@rules_proto//proto:defs.bzl", "proto_library")`

which results in following error on bazel 8:

```
ERROR: /private/var/tmp/_bazel_adincebic/1899d14f6acb23e5b475897f501caf4b/external/toolchains_protoc++protoc+toolchains_protoc_hub.osx_aarch_64/BUILD.bazel:13:1: name 'proto_library' is not defined
```

Not sure if this happens on earlier versions of bazel as this rule might have been vendored similar to rules_android and others.