### PR TITLE
Provide bazelrc preset definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ common --per_file_copt=external/.*grpc.*@--GRPC_WAS_NOT_SUPPOSED_TO_BE_BUILT
 common --host_per_file_copt=external/.*grpc.*@--GRPC_WAS_NOT_SUPPOSED_TO_BE_BUILT
 ```
 
+or if you are using [bazelrc-preset.bzl](https://github.com/bazel-contrib/bazelrc-preset.bzl), you can extend your presets using the `PROTOC_TOOLCHAIN_FLAGS` preset defined in this repository.
+
+```starlark
+load("@bazelrc-preset.bzl", "bazelrc_preset")
+load("@toolchains_protoc//protoc:flags.bzl", "PROTOC_TOOLCHAIN_FLAGS")
+
+bazelrc_preset(
+    name = "preset",
+    extra_presets = PROTOC_TOOLCHAIN_FLAGS,
+)
+```
+
+Once you update your presets, all necessary flags will be added to your preset bazelrc.
+
 ## Support matrix
 
 Minimum versions:

--- a/protoc/flags.bzl
+++ b/protoc/flags.bzl
@@ -1,0 +1,25 @@
+PROTOC_TOOLCHAIN_FLAGS = {
+    "incompatible_enable_proto_toolchain_resolution": struct(
+        default = True,
+        description = """\
+        Bazel 7 introduced this flag to allow us fetch `protoc` rather than re-build it!
+        That flag ALSO decouples how each built-in language rule (Java, Python, C++, etc.) locates the runtime.
+        """,
+    ),
+    "per_file_copt": struct(
+        default = "external/.*protobuf.*@--PROTOBUF_WAS_NOT_SUPPOSED_TO_BE_BUILT",
+        description = "Make sure protobuf is not built from source",
+    ),
+    "host_per_file_copt": struct(
+        default = "external/.*protobuf.*@--PROTOBUF_WAS_NOT_SUPPOSED_TO_BE_BUILT",
+        description = "Make sure protobuf is not built from source",
+    ),
+    "per_file_copt_grpc": struct(
+        default = "external/.*grpc.*@--GRPC_WAS_NOT_SUPPOSED_TO_BE_BUILT",
+        description = "Make sure grpc is not built from source",
+    ),
+    "host_per_file_copt_grpc": struct(
+        default = "external/.*grpc.*@--GRPC_WAS_NOT_SUPPOSED_TO_BE_BUILT",
+        description = "Make sure grpc is not built from source",
+    ),
+}


### PR DESCRIPTION
https://github.com/bazel-contrib/bazelrc-preset.bzl/pull/62 introduced the new `extra_presets` attribute. Now this project can define its relevant presets in a compatible datastructure so that it can be included in the bazelrc presets.

Another benefit: In case the presets of this project change and users update to a more recent version, the diff test of `bazelrc_preset` will fail and make them aware of the changes. Else they might miss them unless they review the release notes or README again. 