### PR TITLE
Fix pre-commit deprecation warnings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,18 +1,17 @@
 {
-    "build": {
-      // instructs devcontainers to use a Dockerfile
-      // rather than a pre-defined image
-      "dockerfile": "Dockerfile"
-    },
-    "customizations": {
-      "vscode": {
-        "extensions": [
-          "ms-azuretools.vscode-docker", // docker support
-          "BazelBuild.vscode-bazel" // bazel support
-        ]
-      }
-    },
-    // sets up pre-commit hooks
-    "postStartCommand": "pre-commit install"
-  }
-  
+  "build": {
+    // instructs devcontainers to use a Dockerfile
+    // rather than a pre-defined image
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-docker", // docker support
+        "BazelBuild.vscode-bazel" // bazel support
+      ]
+    }
+  },
+  // sets up pre-commit hooks
+  "postStartCommand": "pre-commit install"
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 # Commitizen runs in commit-msg stage
 # but we don't want to run the other hooks on commit messages
-default_stages: [commit]
+default_stages: [pre-commit]
 
 # Use a slightly older version of node by default
 # as the default uses a very new version of GLIBC


### PR DESCRIPTION
Working in this repository with the latest version of `pre-commit` leads to the following:

>  Error: [WARNING] top-level `default_stages` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.

This PR is the result of running `pre-commit migrate-config` and allowing it to apply lint fixes to all files.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
